### PR TITLE
telegbot: REQUEST_TIMEOUT is now double of LONG_POLLING_TIMEOUT

### DIFF
--- a/telegapi/telegbot.py
+++ b/telegapi/telegbot.py
@@ -40,7 +40,7 @@ from telegapi.logger import Logger
 logger = Logger()
 
 LONG_POLLING_TIMEOUT = 20
-REQUEST_TIMEOUT = 40  # must be greater than LONG_POLLING_TIMEOUT
+REQUEST_TIMEOUT = LONG_POLLING_TIMEOUT * 2
 
 
 class TelegBot:


### PR DESCRIPTION
Prevent `request_timeout` from getting out of sync with `long_polling_timeout`
