### PR TITLE
Add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,55 @@ bot.on_receive_message = receive_message
 bot.connect()
 bot.run()
 ```
+
+### Plugins
+There's also support for plugins. If you want to extend the functionality writting plugins, make a folder for them and pass it to the `load_plugins` method.
+
+The file in which is contented must have the same name as the class (first letter can be lowercased). And note it must inherit from `Plugin`.   
+An `exampleplugin.py` file:
+```python
+from telegapi.plugin import Plugin
+
+
+class Exampleplugin(Plugin):
+    def example(self):
+        print('Hi! I\'m an example plugin method')
+
+    def looper(self, times, msg):
+        if msg['from']['username'] == self.telegBot.data['username']:
+            return
+
+        for i in range(times):
+            self.telegBot.send_message(msg["chat"]["id"], "Hi")
+```
+
+After this, drop it to your plugin folder and let's do an example bot using plugins:
+```python
+from telegapi.telegbot import TelegBot
+from telegapi.logger import Logger
+
+logger = Logger()
+import time, json
+
+def receive_message(msg):
+    if msg["date"] < time.time() - 2:
+        return  # old
+    logger.msg(msg)
+    bot.exampleplugin.looper(5, msg)
+
+
+bot = TelegBot('TOKEN')
+bot.load_plugins('PLUGINDIRECTORYPATH')
+bot.on_receive_message = receive_message
+bot.exampleplugin.example()
+bot.connect()
+bot.run()
+```
+
+It shows:
+```
+Hi! I'm an example plugin method
+...
+```
+
+`PLUGINDIRECTORYPATH` can also be relative.

--- a/telegapi/plugin.py
+++ b/telegapi/plugin.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+################################################################################
+#                                                                              #
+#   telegbot.py                                                                #
+#                                                                              #
+#   Main teleg-api-bot class, it represents a bot.                             #
+#                                                                              #
+#                                                                              #
+#                                                                              #
+#   Copyright (C) 2015 LibreLabUCM All Rights Reserved.                        #
+#                                                                              #
+#   This file is part of teleg-api-bot.                                        #
+#                                                                              #
+#   This program is free software: you can redistribute it and/or modify       #
+#   it under the terms of the GNU General Public License as published by       #
+#   the Free Software Foundation, either version 3 of the License, or          #
+#   (at your option) any later version.                                        #
+#                                                                              #
+#   This program is distributed in the hope that it will be useful,            #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of             #
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
+#   GNU General Public License for more details.                               #
+#                                                                              #
+#   You should have received a copy of the GNU General Public License          #
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.      #
+#                                                                              #
+################################################################################
+
+# The name of your plugin, inherited from this class, and the filename in which is contained must coincide
+#   but you can lowercase the first letter of the file.
+
+
+class Plugin:
+    def __init__(self, telegBot):
+        self.telegBot = telegBot


### PR DESCRIPTION
Close #21.
The usage it's explained in the readme but to sum it up:
- The plugin class must have the same name as the file (latter can have the first letter lowercased)
- It works with absolute and relative paths
- I preferred to have an attribute (as a namespace) for the plugin to avoid method and variables overlapping
